### PR TITLE
add gcelistimg to gceimgutils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ dist/
 .pytest_cache
 .coverage
 htmlcov/
+.vscode
 
 ### Vim ###
 # swap

--- a/gcelistimg
+++ b/gcelistimg
@@ -23,47 +23,20 @@ import os
 import sys
 
 import gceimgutils.gceutils as utils
-import gceimgutils.gceremoveimg as gcermimg
-
-from gceimgutils.gceimgutilsExceptions import (
-    GCEProjectCredentialsException
-)
+import gceimgutils.gcelistimg as gcelsimg
 
 # Set up command line argument parsing
-argparse = argparse.ArgumentParser(description='Remove images in GCE')
-argparse.add_argument(
-    '--all',
-    action='store_true',
-    default=False,
-    dest='all',
-    help='Delete all images that match the search criteria'
-)
-argparse.add_argument(
-    '--confirm',
-    action='store_true',
-    default=False,
-    dest='confirm',
-    help='Remove matched images with confirmation of action'
-)
+argparse = argparse.ArgumentParser(description='List images in GCE')
 argparse.add_argument(
     '-c', '--credentials-file',
     dest='credentials_file_path',
     help='Path to the service account credentials file',
     metavar='CREDENTIALS_FILE'
 )
-help_msg = 'Do not perform any action, print information about actions that '
-help_msg += 'would be performed instead (Optional)'
-argparse.add_argument(
-    '-n', '--dry-run',
-    action='store_true',
-    default=False,
-    dest='dry_run',
-    help=help_msg
-)
 argparse.add_argument(
     '-p', '--project',
     dest='project_name',
-    help='Project to use for image deletion',
+    help='Project to use for image listing',
     metavar='PROJECT_NAME',
     required=True
 )
@@ -72,24 +45,24 @@ argparse.add_argument(
 # also requires one argument to be specified even if --version is specified
 # This parser behavior is true even if --version and the group are part of the
 # same subgroup
-remove_image_condition_group = argparse.add_mutually_exclusive_group()
-remove_image_condition_group.add_argument(
+list_image_condition_group = argparse.add_mutually_exclusive_group()
+list_image_condition_group.add_argument(
     '--image-name',
     dest='image_name',
-    help='The image name of the image to be removed (Optional)',
+    help='The image name of the image to be listed (Optional)',
     metavar='IMAGE_NAME'
 )
 help_msg = 'An image name fragment to match the image name of the image to be '
-help_msg += 'removed (Optional)'
-remove_image_condition_group.add_argument(
+help_msg += 'lisetd (Optional)'
+list_image_condition_group.add_argument(
     '--image-name-frag',
     dest='image_name_frag',
     help=help_msg,
     metavar='IMAGE_NAME_FRAGMENT'
 )
 help_msg = 'A regular expression to match the image name of the image to be '
-help_msg += 'removed (Optional)'
-remove_image_condition_group.add_argument(
+help_msg += 'listed (Optional)'
+list_image_condition_group.add_argument(
     '--image-name-match',
     dest='image_name_match',
     help=help_msg,
@@ -100,7 +73,14 @@ argparse.add_argument(
     action='store_true',
     default=False,
     dest='verbose',
-    help='Enable on verbose output'
+    help='Enable debug output'
+)
+argparse.add_argument(
+    '--detail',
+    action='store_true',
+    default=False,
+    dest='detail',
+    help='Enables detailed image output'
 )
 argparse.add_argument(
     '--version',
@@ -113,17 +93,6 @@ args = argparse.parse_args()
 
 logger = utils.get_logger(args.verbose)
 
-# Explicit check required to to the group issue, see comment above
-if (
-        not args.image_name and not
-        args.image_name_frag and not
-        args.image_name_match):
-    error_msg = 'gceremoveimg: error: one of the arguments '
-    error_msg += '--image-name --image-name-frag '
-    error_msg += '--image-name-match is required'
-    logger.error(error_msg)
-    sys.exit(1)
-
 credentials_file = None
 if args.credentials_file_path:
     credentials_file = os.path.expanduser(args.credentials_file_path)
@@ -132,8 +101,7 @@ log_level = logging.INFO
 if args.verbose:
     logging.DEBUG
 
-remover = gcermimg.GCERemoveImage(
-    confirm=args.confirm,
+lister = gcelsimg.GCEListImage(
     credentials_path=credentials_file,
     image_name=args.image_name,
     image_name_fragment=args.image_name_frag,
@@ -141,16 +109,14 @@ remover = gcermimg.GCERemoveImage(
     log_callback=logger,
     log_level=log_level,
     project=args.project_name,
-    remove_all=args.all
+    detail=args.detail
 )
 
 try:
-    if args.dry_run:
-        logger.info('Dry run, the following images would be removed from '
-                    'project "%s"' % args.project_name)
-        remover.print_remove_info()
-    else:
-        remover.remove_images()
+    lister.list_images()
 except Exception as e:
-    logger.exception(e)
+    if args.verbose:
+        logger.exception(e)
+    else:
+        logger.info(f"Error: Unable to list images {e}")
     sys.exit(1)

--- a/lib/gceimgutils/gceimgutilsExceptions.py
+++ b/lib/gceimgutils/gceimgutilsExceptions.py
@@ -22,3 +22,7 @@ class GCEProjectCredentialsException(Exception):
 
 class GCERemoveImgException(Exception):
     pass
+
+
+class GCEListImgException(Exception):
+    pass

--- a/lib/gceimgutils/gcelistimg.py
+++ b/lib/gceimgutils/gcelistimg.py
@@ -1,0 +1,97 @@
+# Copyright 2021 SUSE LLC
+#
+# This file is part of gceimgutils
+#
+# gceimgutils is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# gceimgutils is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with gcelistimg. If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+import json
+
+import gceimgutils.gceutils as utils
+
+from gceimgutils.gceimgutils import GCEImageUtils
+from gceimgutils.gceimgutilsExceptions import GCEListImgException
+
+
+class GCEListImage(GCEImageUtils):
+    """Class to list images from GCE project"""
+
+    # ---------------------------------------------------------------------
+    def __init__(
+            self,
+            credentials_path=None,
+            image_name=None,
+            image_name_fragment=None,
+            image_name_match=None,
+            log_callback=None,
+            log_level=logging.INFO,
+            project=None,
+            detail=False
+    ):
+        GCEImageUtils.__init__(
+            self, project, credentials_path,
+            log_level, log_callback
+        )
+
+        self.image_name = image_name
+        self.image_name_fragment = image_name_fragment
+        self.image_name_match = image_name_match
+        self.detail = detail
+
+    # ---------------------------------------------------------------------
+    def get_images(self):
+        """Get images from sdk"""
+        owned_images = utils.get_project_images(
+            self.project, self.credentials, True
+        )
+
+        if self.image_name:
+            return utils.find_images_by_name(
+                owned_images,
+                self.image_name,
+                self.log
+            )
+        elif self.image_name_fragment:
+            return utils.find_images_by_name_fragment(
+                owned_images,
+                self.image_name_fragment,
+                self.log
+            )
+        elif self.image_name_match:
+            try:
+                return utils.find_images_by_name_regex_match(
+                    owned_images,
+                    self.image_name_match,
+                    self.log
+                )
+            except Exception:
+                msg = 'Unable to complie regular expression "%s"'
+                msg = msg % self.image_name_match
+                raise GCEListImgException(msg)
+        else:
+            return(owned_images)
+
+    # ---------------------------------------------------------------------
+    def list_images(self):
+        """List the images"""
+        images = self.get_images()
+
+        if not images:
+            raise GCEListImgException('No Images found')
+
+        for image in images:
+            if self.detail or self.image_name:
+                print(json.dumps(image, indent=4))
+            else:
+                print(image['name'])

--- a/man/man1/gcelistimg.1
+++ b/man/man1/gcelistimg.1
@@ -1,0 +1,56 @@
+.\" Process this file with
+.\" groff -man -Tascii gcelistimg.1
+.\"
+.TH gcelistimg 1
+.SH NAME
+gcelistimg \- List images in GCE
+.SH SYNOPSIS
+.B gcelistimg [option]
+.SH DESCRIPTION
+.B gcelistimg
+List an image owned by the given GCE project.
+.SH OPTIONS
+.IP "-c --credentials-file CONFIG_FILE"
+Specifies the service account credentials to use. By default service account
+credentials are expected in
+.IR ~/.config/gce.
+The crendentials file must match the given project name followed by the
+.IR .json
+extension.
+.IP "--image-name IMAGE_NAME"
+Specify the name of the image to be listed. The program will look for
+an exact match of the name. This option is mutually exclusive with
+.IR --image-name-frag ,
+and
+.IR --image-name-match .
+.IP "--image-name-frag IMAGE_NAME_FRAGMENT"
+Specify a section of an image name for the image(s) to be listed. Every
+image that matches the name fragment will be listed. This
+option is mutually exclusive with
+.IR --image-name ,
+and
+.IR --image-name-match .
+.IP "--image-name-match REGEX"
+Specify a regular expression to match an image name. Every image matching the
+regular expression will be listed. This option is mutually
+exclusive with
+.IR --image-name ,
+and
+.IR --image-name-frag .
+.IP "-p --project PROJECT_NAME"
+Specifies the project name to use to connect to GCE and used to search for the
+image to be listed.
+.IP "--verbose"
+Print extra output about the operations performed to STDOUT.
+.IP "--detail"
+Print full image attributes. Without this option, only the name is printed to STDOUT.
+.IP "--version"
+Print the version of he program
+.SH EXAMPLE
+gcelistimg --project example --image-name-match '.*v15.*' --detail --verbose
+
+Will list all images that match the
+.I .*v15.*
+regular expression in the image name. The image details will be written to STDOUT.
+.SH AUTHOR
+SUSE Public Cloud Team (public-cloud-dev@susecloud.net)

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,8 @@ if __name__ == '__main__':
             '': 'lib',
         },
         scripts=[
-            'gceremoveimg'
+            'gceremoveimg',
+            'gcelistimg'
         ],
         classifiers=[
             'Development Status :: 4 - Beta',
@@ -77,4 +78,3 @@ if __name__ == '__main__':
             'Programming Language :: Python :: Implementation :: PyPy',
         ]
     )
-


### PR DESCRIPTION
The PR implements the gcelistimg CLI and API.  It uses the relevant options from gceremoveimg for consistency.  A new `--detail` option was added to allow for retrieving the full image details.