### PR TITLE
Use lazy properties to get compute driver

### DIFF
--- a/lib/gceimgutils/gceimgutils.py
+++ b/lib/gceimgutils/gceimgutils.py
@@ -19,10 +19,6 @@ import logging
 
 import gceimgutils.gceutils as utils
 
-from google.auth.exceptions import RefreshError
-
-from gceimgutils.gceimgutilsExceptions import GCEImgUtilsException
-
 
 class GCEImageUtils():
     """Base class for GCE Image Utilities"""
@@ -56,22 +52,6 @@ class GCEImageUtils():
         """Get an authenticated compute driver"""
         if not self._compute_driver:
             self._compute_driver = utils.get_compute_api(self.credentials)
-
-            try:
-                # Force auth to catch errors in one place
-                self._compute_driver.images().list(
-                    project=self.project,
-                    maxResults=1
-                ).execute()
-            except RefreshError:
-                raise GCEImgUtilsException(
-                    'The provided credentials are invalid or expired: '
-                    '{creds_file}'.format(creds_file=self.credentials_path)
-                )
-            except Exception as error:
-                raise GCEImgUtilsException(
-                    'GCP authentication failed: {error}'.format(error=error)
-                )
 
         return self._compute_driver
 

--- a/lib/gceimgutils/gceimgutilsExceptions.py
+++ b/lib/gceimgutils/gceimgutilsExceptions.py
@@ -16,13 +16,17 @@
 # along with gceimgutils.  If not, see <http://www.gnu.org/licenses/>.
 
 
-class GCEProjectCredentialsException(Exception):
+class GCEImgUtilsException(Exception):
     pass
 
 
-class GCERemoveImgException(Exception):
+class GCEProjectCredentialsException(GCEImgUtilsException):
     pass
 
 
-class GCEListImgException(Exception):
+class GCERemoveImgException(GCEImgUtilsException):
+    pass
+
+
+class GCEListImgException(GCEImgUtilsException):
     pass

--- a/lib/gceimgutils/gcelistimg.py
+++ b/lib/gceimgutils/gcelistimg.py
@@ -53,7 +53,9 @@ class GCEListImage(GCEImageUtils):
     def get_images(self):
         """Get images from sdk"""
         owned_images = utils.get_project_images(
-            self.project, self.credentials, True
+            self.compute_driver,
+            self.project,
+            True
         )
 
         if self.image_name:

--- a/lib/gceimgutils/gceremoveimg.py
+++ b/lib/gceimgutils/gceremoveimg.py
@@ -76,7 +76,9 @@ class GCERemoveImage(GCEImageUtils):
     def _get_images_to_remove(self):
         """Find the images to remove"""
         owned_images = utils.get_project_images(
-            self.project, self.credentials, True
+            self.compute_driver,
+            self.project,
+            True
         )
         if self.image_name:
             return utils.find_images_by_name(
@@ -151,7 +153,7 @@ class GCERemoveImage(GCEImageUtils):
 
         if delete:
             try:
-                self._get_api().images().delete(
+                self.compute_driver.images().delete(
                     project=self.project, image=image_name
                 ).execute()
             except HttpError as error:

--- a/lib/gceimgutils/gceutils.py
+++ b/lib/gceimgutils/gceutils.py
@@ -100,9 +100,10 @@ def get_credentials(project_name=None, credentials_file=None):
         credentials = service_account.Credentials.from_service_account_file(
             credentials_file
         )
-    except Exception:
+    except Exception as error:
         raise GCEProjectCredentialsException(
-            'Could not extract credentials from "%s"' % credentials_file
+            'Could not extract credentials from "{credentials_file}": '
+            '{error}'.format(credentials_file=credentials_file, error=error)
         )
 
     return credentials
@@ -130,12 +131,12 @@ def get_logger(verbose):
 
 
 # ----------------------------------------------------------------------------
-def get_project_images(project_name, credentials, deprecated=False):
+def get_project_images(compute_driver, project_name, deprecated=False):
     """Get the images owned by the given project"""
 
     current_images = []
     try:
-        response = get_compute_api(credentials).images().list(
+        response = compute_driver.images().list(
             project=project_name).execute()
     except HttpError:
         return current_images

--- a/test/unit/test_gceutils.py
+++ b/test/unit/test_gceutils.py
@@ -161,8 +161,10 @@ def test_get_credentials_format_error():
             credentials_file=cred_file
         )
     except GCEProjectCredentialsException as ex:
-        expected_msg = 'Could not extract credentials from "%s"' % cred_file
-        assert expected_msg == format(ex)
+        expected_msg = 'Could not extract credentials from "{cred_file}": ' \
+                       'Service account info was not in the ' \
+                       'expected format'.format(cred_file=cred_file)
+        assert expected_msg in format(ex)
 
 
 # --------------------------------------------------------------------


### PR DESCRIPTION
And credentials from json file. This allows the code to re-use
existing drivers and to catch all auth related exceptions in one
spot so a clearer error message can be provided.

Fixes #9 