### PR TITLE
Credential path can be None

### DIFF
--- a/lib/gceimgutils/gceimgutils.py
+++ b/lib/gceimgutils/gceimgutils.py
@@ -16,7 +16,6 @@
 # along with gceimgutils.ase.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-import os
 
 import gceimgutils.gceutils as utils
 
@@ -31,7 +30,7 @@ class GCEImageUtils():
     ):
 
         self.project = project
-        self.credentials_path = os.path.expanduser(credentials_path)
+        self.credentials_path = credentials_path
         self._credentials = None
         self._compute_driver = None
 

--- a/lib/gceimgutils/gcelistimg.py
+++ b/lib/gceimgutils/gcelistimg.py
@@ -82,7 +82,7 @@ class GCEListImage(GCEImageUtils):
                 msg = msg % self.image_name_match
                 raise GCEListImgException(msg)
         else:
-            return(owned_images)
+            return owned_images
 
     # ---------------------------------------------------------------------
     def list_images(self):


### PR DESCRIPTION
Prevent type error by dropping expanduser call. The expanduser
function is handled in utils when doing authentication.