### PR TITLE
Add labels option to create image function and CLI

### DIFF
--- a/gcecreateimg
+++ b/gcecreateimg
@@ -89,6 +89,12 @@ argparse.add_argument(
     help='A comma separated list of applicable license URI\'s'
 )
 argparse.add_argument(
+    '--labels',
+    dest='labels',
+    help='A comma separated list of key=value label pairs '
+         '(e.g. env=prod,team=platform)'
+)
+argparse.add_argument(
     '--verbose',
     action='store_true',
     default=False,
@@ -132,6 +138,22 @@ if args.licenses:
 else:
     licenses = []
 
+labels = None
+if args.labels:
+    labels = {}
+    for pair in args.labels.split(','):
+        key, sep, value = pair.partition('=')
+        key = key.strip()
+        value = value.strip()
+        if not sep or not key:
+            error_msg = (
+                f'gcecreateimg: error: invalid label format "{pair.strip()}".'
+                ' Expected key=value'
+            )
+            logger.error(error_msg)
+            sys.exit(1)
+        labels[key] = value
+
 creater = GCECreateImage(
     args.image_name,
     args.image_description,
@@ -141,6 +163,7 @@ creater = GCECreateImage(
     args.family,
     guest_os_features,
     licenses,
+    labels=labels,
     credentials_path=credentials_file,
     project=args.project_name,
     log_callback=logger,

--- a/gcecreateimg
+++ b/gcecreateimg
@@ -142,17 +142,17 @@ labels = None
 if args.labels:
     labels = {}
     for pair in args.labels.split(','):
-        key, sep, value = pair.partition('=')
-        key = key.strip()
-        value = value.strip()
-        if not sep or not key:
+        try:
+            key, value = pair.split('=')
+        except ValueError:
             error_msg = (
                 f'gcecreateimg: error: invalid label format "{pair.strip()}".'
                 ' Expected key=value'
             )
             logger.error(error_msg)
             sys.exit(1)
-        labels[key] = value
+
+        labels[key.strip()] = value.strip()
 
 creater = GCECreateImage(
     args.image_name,

--- a/lib/gceimgutils/gcecreateimg.py
+++ b/lib/gceimgutils/gcecreateimg.py
@@ -42,6 +42,7 @@ class GCECreateImage(GCEImageUtils):
         family=None,
         guest_os_features=None,
         licenses=None,
+        labels=None,
         credentials_path=None,
         credentials_info=None,
         project=None,
@@ -69,6 +70,7 @@ class GCECreateImage(GCEImageUtils):
         self.architecture = architecture
         self.guest_os_features = guest_os_features
         self.licenses = licenses
+        self.labels = labels
 
     # ---------------------------------------------------------------------
     def create_image(self):
@@ -90,6 +92,9 @@ class GCECreateImage(GCEImageUtils):
 
         if self.licenses:
             mapping['licenses'] = self.licenses
+
+        if self.labels:
+            mapping['labels'] = self.labels
 
         image = compute_v1.Image(mapping)
 

--- a/lib/gceimgutils/gcecreateimg.py
+++ b/lib/gceimgutils/gcecreateimg.py
@@ -42,12 +42,12 @@ class GCECreateImage(GCEImageUtils):
         family=None,
         guest_os_features=None,
         licenses=None,
-        labels=None,
         credentials_path=None,
         credentials_info=None,
         project=None,
         log_callback=None,
         log_level=logging.INFO,
+        labels=None,
     ):
         GCEImageUtils.__init__(
             self,

--- a/test/unit/test_gcecreateimg.py
+++ b/test/unit/test_gcecreateimg.py
@@ -79,3 +79,48 @@ class TestGCECreateImage(object):
 
         msg = 'Unable to create image: "image123". Invalid credentials!'
         assert str(error.value) == msg
+
+    @patch('gceimgutils.gceutils.time')
+    @patch('gceimgutils.gceutils.compute_v1')
+    @patch('gceimgutils.gceutils.AuthorizedSession')
+    def test_create_image_with_labels(
+        self,
+        mock_auth_session,
+        mock_compute_v1,
+        mock_time
+    ):
+        mock_compute_v1.ImagesClient.return_value = self.images_client
+
+        self.operation.error_code = None
+        self.operation.warnings = None
+        self.operation.result.return_value = 0
+
+        kwargs = dict(self.kwargs)
+        kwargs['labels'] = {'env': 'test', 'team': 'qa'}
+        creator = GCECreateImage(**kwargs)
+        creator.create_image()
+
+        call_kwargs = self.images_client.insert.call_args.kwargs
+        image_resource = call_kwargs['image_resource']
+        assert dict(image_resource.labels) == {'env': 'test', 'team': 'qa'}
+
+    @patch('gceimgutils.gceutils.time')
+    @patch('gceimgutils.gceutils.compute_v1')
+    @patch('gceimgutils.gceutils.AuthorizedSession')
+    def test_create_image_without_labels(
+        self,
+        mock_auth_session,
+        mock_compute_v1,
+        mock_time
+    ):
+        mock_compute_v1.ImagesClient.return_value = self.images_client
+
+        self.operation.error_code = None
+        self.operation.warnings = None
+        self.operation.result.return_value = 0
+
+        self.creator.create_image()
+
+        call_kwargs = self.images_client.insert.call_args.kwargs
+        image_resource = call_kwargs['image_resource']
+        assert dict(image_resource.labels) == {}


### PR DESCRIPTION
Add support for optional labels as key=value pairs when creating GCE images. Labels are passed through to the compute_v1.Image API call. When no labels are provided, the labels field is omitted from the API payload entirely.

Changes:
- Add --labels CLI argument accepting comma-separated key=value pairs (e.g. --labels env=prod,team=platform)
- Add labels parameter to GCECreateImage class constructor
- Include labels in image creation mapping only when provided
- Add tests for image creation with and without labels